### PR TITLE
WORDS_BIGENDIAN is provided by MachDeps.h

### DIFF
--- a/Data/FastPack/TH.hs
+++ b/Data/FastPack/TH.hs
@@ -14,6 +14,7 @@ import           Data.FastPack.Types
 
 import           Language.Haskell.TH.Syntax
 
+#include "MachDeps.h"
 
 mkConE :: String -> Exp
 mkConE = ConE . mkName


### PR DESCRIPTION
Without this, it won't work on big-endian platforms.