### PR TITLE
Testbench

### DIFF
--- a/bench/Bench/Binary.hs
+++ b/bench/Bench/Binary.hs
@@ -38,7 +38,3 @@ getBenchWord bs =
         <*> BG.getWord16be
         <*> BG.getWord8
         <*> BG.getWord8
-
-{-# NOINLINE sanityBenchWord #-}
-sanityBenchWord :: BenchWord -> BenchWord
-sanityBenchWord = getBenchWord . putBenchWord

--- a/bench/Bench/Cereal.hs
+++ b/bench/Bench/Cereal.hs
@@ -41,7 +41,3 @@ getBenchWord bs =
         <*> CG.getWord16be
         <*> CG.getWord8
         <*> CG.getWord8
-
-{-# NOINLINE sanityBenchWord #-}
-sanityBenchWord :: BenchWord -> BenchWord
-sanityBenchWord = getBenchWord . putBenchWord

--- a/bench/Bench/FastPack.hs
+++ b/bench/Bench/FastPack.hs
@@ -50,8 +50,3 @@ getBenchWordRaw bs =
         , GetNum PackW8
         , GetNum PackW8
         ])
-
-
-{-# NOINLINE sanityBenchWord #-}
-sanityBenchWord :: BenchWord -> BenchWord
-sanityBenchWord = getBenchWord . putBenchWord

--- a/bench/Bench/Packer.hs
+++ b/bench/Bench/Packer.hs
@@ -37,7 +37,3 @@ getBenchWord bs =
         <*> P.getWord16BE
         <*> P.getWord8
         <*> P.getWord8
-
-{-# NOINLINE sanityBenchWord #-}
-sanityBenchWord :: BenchWord -> BenchWord
-sanityBenchWord = getBenchWord . putBenchWord

--- a/bench/bench.hs
+++ b/bench/bench.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DataKinds, KindSignatures, RankNTypes, TypeApplications #-}
 
 import qualified Bench.Binary as Binary
 import qualified Bench.Cereal as Cereal
@@ -9,57 +10,66 @@ import           Bench.Types
 import           Data.ByteString (ByteString)
 import qualified Data.ByteString.Char8 as BS
 import qualified Data.List as DL
+import           Data.Proxy (Proxy(..))
 
-import qualified Criterion.Main as C
-
+import TestBench
 
 main :: IO ()
-main = do
-    sanityCheck
-    putStrLn "\nPassed sanity test.\n"
-    C.defaultMain benchmarks
-
+main =
+  testBench $ do
+    compareFunc "Write to ByteString"
+                (`withLibrary` (\l -> putBenchTest (putBenchWord l) bws))
+                (uncurry baseline (head libraries))
+                (mapM_ (uncurry comp) (tail libraries))
+    compareFunc "Read from ByteString"
+               (`withLibrary` (\l -> getBenchTest (getBenchWord l) bss))
+               (uncurry baseline (head libraries))
+               (mapM_ (uncurry comp) (tail libraries))
+  where
+    (bws, bss) = genBenchData 100000
 
 --------------------------------------------------------------------------------
 -- The benchmarks.
 
-benchmarks :: [C.Benchmark]
-benchmarks =
-    let (bws, bss) = genBenchData 100000 in
-    [ C.bgroup "Write to ByteString"
-        [ C.bench "Binary"      $ C.whnf (putBenchTest Binary.putBenchWord) bws
-        , C.bench "Cereal"      $ C.whnf (putBenchTest Cereal.putBenchWord) bws
-        , C.bench "Packer"      $ C.whnf (putBenchTest Packer.putBenchWord) bws
-        , C.bench "FastPack"    $ C.whnf (putBenchTest FastPack.putBenchWord) bws
-        ]
-    , C.bgroup "Read from ByteString"
-        [ C.bench "Binary"      $ C.whnf (getBenchTest Binary.getBenchWord) bss
-        , C.bench "Cereal"      $ C.whnf (getBenchTest Cereal.getBenchWord) bss
-        , C.bench "Packer"      $ C.whnf (getBenchTest Packer.getBenchWord) bss
-        , C.bench "FastPack"    $ C.whnf (getBenchTest FastPack.getBenchWord) bss
-        ]
-    ]
+data Library = Binary
+             | Cereal
+             | Packer
+             | FastPack
+  deriving (Eq, Ord, Show, Read, Enum, Bounded)
 
+libraries :: [(String, Library)]
+libraries = map ((,) =<< show) [minBound .. maxBound]
 
+withLibrary :: Library -> (forall l. (PutGet l) => Proxy l -> k) -> k
+withLibrary Binary   k = (k (Proxy @'Binary))
+withLibrary Cereal   k = (k (Proxy @'Cereal))
+withLibrary Packer   k = (k (Proxy @'Packer))
+withLibrary FastPack k = (k (Proxy @'FastPack))
+
+class PutGet (l :: Library) where
+
+  putBenchWord :: Proxy l -> BenchWord -> ByteString
+
+  getBenchWord :: Proxy l -> ByteString -> BenchWord
+
+instance PutGet 'Binary where
+  putBenchWord _ = Binary.putBenchWord
+  getBenchWord _ = Binary.getBenchWord
+
+instance PutGet 'Cereal where
+  putBenchWord _ = Cereal.putBenchWord
+  getBenchWord _ = Cereal.getBenchWord
+
+instance PutGet 'Packer where
+  putBenchWord _ = Packer.putBenchWord
+  getBenchWord _ = Packer.getBenchWord
+
+instance PutGet 'FastPack where
+  putBenchWord _ = FastPack.putBenchWord
+  getBenchWord _ = FastPack.getBenchWord
 
 putBenchTest :: (BenchWord -> ByteString) -> [BenchWord] -> Int
 putBenchTest put = DL.foldl' (\ acc bw -> acc + BS.length (put bw)) 0
 
 getBenchTest :: (ByteString -> BenchWord) -> [ByteString] -> Int
 getBenchTest get = DL.foldl' (\ acc bs -> acc + fromIntegral (getThird $ get bs)) 0
-
-
-sanityCheck :: IO ()
-sanityCheck = do
-    assert "Binary" $ Binary.sanityBenchWord bw == bw
-    assert "Cereal" $ Cereal.sanityBenchWord bw == bw
-    assert "Packer" $ Packer.sanityBenchWord bw == bw
-    assert "FastPack" $ FastPack.sanityBenchWord bw == bw
-  where
-    bw = BenchWord  0x123456789abcdef  0xabcdef123456789
-                    0x87654321 0x76543210 0x1234 0x2345 0x55 0xaa
-
-    assert name prop =
-        if prop
-            then pure ()
-            else error $ name ++ " failed assertion!"

--- a/bench/bench.hs
+++ b/bench/bench.hs
@@ -68,6 +68,10 @@ instance PutGet 'FastPack where
   putBenchWord _ = FastPack.putBenchWord
   getBenchWord _ = FastPack.getBenchWord
 
+{-# NOINLINE sanityBenchWord #-}
+sanityBenchWord :: (PutGet l) => Proxy l -> BenchWord -> BenchWord
+sanityBenchWord p = getBenchWord p . putBenchWord p
+
 putBenchTest :: (BenchWord -> ByteString) -> [BenchWord] -> Int
 putBenchTest put = DL.foldl' (\ acc bw -> acc + BS.length (put bw)) 0
 

--- a/fastpack.cabal
+++ b/fastpack.cabal
@@ -77,6 +77,6 @@ benchmark bench
                     , binary                          == 0.8.*
                     , bytestring
                     , cereal                          == 0.5.*
-                    , criterion                       >= 1.1.4     && < 1.2
                     , fastpack
                     , packer                          == 0.1.*
+                    , testbench                       == 0.1.*


### PR DESCRIPTION
This provides an (IMO) nicer way of writing comparison benchmarks and testing that they all produce the same value.

I've left `sanityBenchWord` in there in case you want to use it for the tests.  It's also trivial to require evaluating to normal form rather than WHNF (though since you're using `StrictData` it's probably not needed).